### PR TITLE
Fix detect_default_branch regression and add debug logging for git failures

### DIFF
--- a/loony_dev/git.py
+++ b/loony_dev/git.py
@@ -15,7 +15,17 @@ class GitRepo:
     def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
         cmd = ["git", *args]
         logger.debug("Running: %s", " ".join(cmd))
-        return subprocess.run(cmd, cwd=self.work_dir, capture_output=True, text=True, check=True)
+        try:
+            return subprocess.run(cmd, cwd=self.work_dir, capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            logger.debug(
+                "git command failed (exit %d): %s\nstdout: %s\nstderr: %s",
+                exc.returncode,
+                " ".join(cmd),
+                (exc.stdout or "").strip(),
+                (exc.stderr or "").strip(),
+            )
+            raise
 
     def ensure_main_up_to_date(self) -> None:
         """Checkout the default branch and pull latest."""

--- a/loony_dev/github.py
+++ b/loony_dev/github.py
@@ -589,8 +589,8 @@ class GitHubClient:
         ``development``).  Falls back to ``"main"`` if detection fails.
         """
         try:
-            branch = self._gh(
-                "repo", "view",
+            branch = _run_gh(
+                "gh", "repo", "view", self.repo,
                 "--json", "defaultBranchRef",
                 "-q", ".defaultBranchRef.name",
             )


### PR DESCRIPTION
## Summary
- **`detect_default_branch` regression fix**: `gh repo view` does not support the `-R` flag — it takes the repo as a positional argument. The refactor in #89 removed the positional arg and relied on `_gh()`'s automatic `-R` append, which broke detection for all repos. Fixed by calling `_run_gh` directly with the repo as a positional argument.
- **`git._run` debug logging**: Failed git commands now log `stdout`, `stderr`, and exit code at `DEBUG` level. Visible with the existing `--verbose` / `-v` flag, stays quiet otherwise — avoids leaking potentially sensitive command output at higher log levels.

## Test plan
- [x] All 147 tests pass
- [ ] Deploy and verify `detect_default_branch` works for repos with non-main default branches
- [ ] Verify `--verbose` surfaces git command failure details

🤖 Generated with [Claude Code](https://claude.com/claude-code)