### PR TITLE
fix(git): handle diverged main branch by resetting to origin

### DIFF
--- a/loony_dev/git.py
+++ b/loony_dev/git.py
@@ -30,7 +30,16 @@ class GitRepo:
     def ensure_main_up_to_date(self) -> None:
         """Checkout the default branch and pull latest."""
         self._run("checkout", self.default_branch)
-        self._run("pull", "--ff-only")
+        self._run("fetch", "origin", self.default_branch)
+        try:
+            self._run("pull", "--ff-only")
+        except subprocess.CalledProcessError:
+            logger.warning(
+                "Fast-forward pull failed; resetting local %s to origin/%s",
+                self.default_branch,
+                self.default_branch,
+            )
+            self._run("reset", "--hard", f"origin/{self.default_branch}")
 
     def has_uncommitted_changes(self) -> bool:
         result = self._run("status", "--porcelain")

--- a/loony_dev/orchestrator.py
+++ b/loony_dev/orchestrator.py
@@ -132,10 +132,11 @@ class Orchestrator:
     def dispatch(self, agent: Agent, task: Task) -> None:
         logger.debug("Task description:\n%s", task.describe())
         task.on_start(self.github)
-        branch = self.git.current_branch()
-        logger.debug("Current branch before sync: %s", branch)
-        has_changes = self.git.has_uncommitted_changes()
-        logger.debug("Uncommitted changes before sync: %s", has_changes)
+        try:
+            logger.debug("Current branch before sync: %s", self.git.current_branch())
+            logger.debug("Uncommitted changes before sync: %s", self.git.has_uncommitted_changes())
+        except Exception:
+            logger.debug("Could not read git state before sync", exc_info=True)
         self.git.ensure_main_up_to_date()
 
         self._active_agent = agent


### PR DESCRIPTION
## Summary
- When local main diverges from origin, `git pull --ff-only` fails and crashes the orchestrator tick loop
- Now fetches first, attempts fast-forward, and falls back to `reset --hard origin/<default_branch>` since the remote is the source of truth
- Wraps pre-sync git state logging in a try/except so failures there don't block the tick

## Test plan
- [ ] Simulate a diverged local main (e.g. local commit + upstream force-push) and verify the orchestrator recovers gracefully
- [ ] Verify normal fast-forward pulls still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)