### PR TITLE
feat(agent): deterministic session continuity across task lifecycle

### DIFF
--- a/loony_dev/agents/claude_quota.py
+++ b/loony_dev/agents/claude_quota.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 
 import logging
 import re
+import subprocess
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 from loony_dev import config
+from loony_dev.session import session_id_for
+
+if TYPE_CHECKING:
+    from loony_dev.tasks.base import Task
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +38,14 @@ _QUOTA_PATTERNS = [
     "hit your limit",
 ]
 
+_SESSION_NOT_FOUND_PATTERNS = (
+    "no session",
+    "session not found",
+    "could not find session",
+    "invalid session",
+    "does not exist",
+)
+
 # Matches: "Your limit will reset at 2pm (America/New_York)"
 #      or: "resets 7:30pm (Asia/Calcutta)"
 _RESET_RE = re.compile(
@@ -48,6 +63,7 @@ class ClaudeQuotaMixin:
     """
 
     _disabled_until: datetime | None = None
+    repo: str = ""  # Set by subclass __init__; used for session ID generation.
 
     def can_handle(self, task: Task) -> bool:
         """Check availability then delegate to subclass task-type check.
@@ -149,3 +165,74 @@ class ClaudeQuotaMixin:
                 fallback,
                 output,
             )
+
+    # ------------------------------------------------------------------
+    # Shared Claude CLI runner with session continuity
+    # ------------------------------------------------------------------
+
+    def _session_id_for(self, task: Task) -> str | None:
+        """Compute a deterministic session ID for *task*, or None."""
+        key = task.session_key
+        if not key or not self.repo:
+            return None
+        return session_id_for(self.repo, key)
+
+    def _run_claude_cli(
+        self,
+        prompt: str,
+        *,
+        cwd: Path,
+        session_id: str | None = None,
+    ) -> tuple[str, str, int]:
+        """Run the Claude CLI with optional session continuity.
+
+        When *session_id* is provided, attempts ``--resume`` first to
+        continue an existing session.  If that fails because no matching
+        session is found, retries with ``--session-id`` to create a new
+        session with the given UUID.
+        """
+        if session_id:
+            stdout, stderr, rc = self._invoke_claude(
+                prompt, cwd=cwd, extra_flags=["--resume", session_id],
+            )
+            if rc == 0 or not self._is_session_not_found(f"{stdout}\n{stderr}"):
+                return stdout, stderr, rc
+            logger.debug("Session %s not found — creating new session", session_id)
+            return self._invoke_claude(
+                prompt, cwd=cwd, extra_flags=["--session-id", session_id],
+            )
+        return self._invoke_claude(prompt, cwd=cwd)
+
+    def _invoke_claude(
+        self,
+        prompt: str,
+        *,
+        cwd: Path,
+        extra_flags: list[str] | None = None,
+    ) -> tuple[str, str, int]:
+        """Spawn ``claude -p`` and return (stdout, stderr, returncode)."""
+        cmd = ["claude", "-p", "--dangerously-skip-permissions"]
+        if extra_flags:
+            cmd.extend(extra_flags)
+        cmd.append(prompt)
+
+        with subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        ) as proc:
+            self._active_process = proc
+            try:
+                stdout, stderr = proc.communicate()
+            finally:
+                self._active_process = None
+        return stdout, stderr, proc.returncode
+
+    @staticmethod
+    def _is_session_not_found(output: str) -> bool:
+        """Return True if *output* indicates a missing/invalid session."""
+        lower = output.lower()
+        return any(p in lower for p in _SESSION_NOT_FOUND_PATTERNS)

--- a/loony_dev/agents/coding.py
+++ b/loony_dev/agents/coding.py
@@ -20,35 +20,28 @@ class CodingAgent(ClaudeQuotaMixin, Agent):
 
     name = "coding"
 
-    def __init__(self, work_dir: Path) -> None:
+    def __init__(self, work_dir: Path, repo: str = "") -> None:
         self.work_dir = work_dir
+        self.repo = repo
 
     def _can_handle_task(self, task: Task) -> bool:
         return task.task_type in ("implement_issue", "address_review", "resolve_conflicts", "fix_ci")
 
     def execute(self, task: Task) -> TaskResult:
         prompt = task.describe()
-        cmd = ["claude", "-p", "--dangerously-skip-permissions", prompt]
-        logger.debug("Running Claude CLI (cwd=%s): claude -p --dangerously-skip-permissions <prompt>", self.work_dir)
+        session_id = self._session_id_for(task)
+        logger.debug(
+            "Running Claude CLI (cwd=%s, session=%s): claude -p --dangerously-skip-permissions <prompt>",
+            self.work_dir, session_id,
+        )
         logger.debug("Claude prompt: %s", truncate_for_log(prompt))
 
         baseline_commit = self._get_head_commit()
 
-        with subprocess.Popen(
-            cmd,
-            cwd=self.work_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-        ) as proc:
-            self._active_process = proc
-            try:
-                stdout, stderr = proc.communicate()
-            finally:
-                self._active_process = None
+        stdout, stderr, returncode = self._run_claude_cli(
+            prompt, cwd=self.work_dir, session_id=session_id,
+        )
 
-        returncode = proc.returncode
         logger.debug("Claude CLI exited with code %d", returncode)
         if stdout:
             logger.debug("Claude stdout: %s", truncate_for_log(stdout))
@@ -114,22 +107,15 @@ class CodingAgent(ClaudeQuotaMixin, Agent):
         summary_prompt = f"Summarize what was done in 2-3 sentences based on this output:\n\n{output[-3000:]}"
         logger.debug("Running summary Claude call")
         logger.debug("Summary prompt: %s", truncate_for_log(summary_prompt))
-        with subprocess.Popen(
-            ["claude", "-p", "--dangerously-skip-permissions", summary_prompt],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-        ) as proc:
-            self._active_process = proc
-            try:
-                stdout, _ = proc.communicate()
-            finally:
-                self._active_process = None
-        logger.debug("Summary Claude call exited with code %d", proc.returncode)
+        # Bypass session: injecting a meta-summarisation turn into the issue
+        # session would corrupt the conversation history that planning and
+        # future review rounds rely on.
+        stdout, _, returncode = self._invoke_claude(
+            summary_prompt, cwd=self.work_dir,
+        )
+        logger.debug("Summary Claude call exited with code %d", returncode)
         if stdout:
             logger.debug("Summary output: %s", truncate_for_log(stdout))
-        if proc.returncode == 0 and stdout.strip():
+        if returncode == 0 and stdout.strip():
             return stdout.strip()
         return "Changes were made successfully."
-

--- a/loony_dev/agents/planning.py
+++ b/loony_dev/agents/planning.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,46 +19,37 @@ class PlanningAgent(ClaudeQuotaMixin, Agent):
 
     name = "planning"
 
-    def __init__(self, work_dir: Path) -> None:
+    def __init__(self, work_dir: Path, repo: str = "") -> None:
         self.work_dir = work_dir
+        self.repo = repo
 
     def _can_handle_task(self, task: Task) -> bool:
         return task.task_type == "plan_issue"
 
     def execute(self, task: Task) -> TaskResult:
         prompt = task.describe()
-        cmd = ["claude", "-p", "--dangerously-skip-permissions", prompt]
-        logger.debug("Running planning Claude CLI (cwd=%s)", self.work_dir)
+        session_id = self._session_id_for(task)
+        logger.debug("Running planning Claude CLI (cwd=%s, session=%s)", self.work_dir, session_id)
         logger.debug("Planning prompt: %s", truncate_for_log(prompt))
 
-        with subprocess.Popen(
-            cmd,
-            cwd=self.work_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-        ) as proc:
-            self._active_process = proc
-            try:
-                stdout, stderr = proc.communicate()
-            finally:
-                self._active_process = None
+        stdout, stderr, returncode = self._run_claude_cli(
+            prompt, cwd=self.work_dir, session_id=session_id,
+        )
 
-        logger.debug("Planning Claude CLI exited with code %d", proc.returncode)
+        logger.debug("Planning Claude CLI exited with code %d", returncode)
         if stdout:
             logger.debug("Planning output (%d chars): %s", len(stdout), truncate_for_log(stdout))
         if stderr:
             logger.debug("Planning stderr: %s", truncate_for_log(stderr))
 
-        if proc.returncode != 0:
+        if returncode != 0:
             combined = f"{stdout}\n{stderr}"
             if self._is_quota_error(combined):
                 self._handle_quota_error(combined)
             return TaskResult(
                 success=False,
                 output=combined,
-                summary=f"Agent exited with code {proc.returncode}",
+                summary=f"Agent exited with code {returncode}",
             )
 
         # The raw output IS the plan; use it directly as the summary so
@@ -69,4 +59,3 @@ class PlanningAgent(ClaudeQuotaMixin, Agent):
             output=stdout,
             summary=stdout.strip(),
         )
-

--- a/loony_dev/cli.py
+++ b/loony_dev/cli.py
@@ -81,7 +81,7 @@ def worker(**_) -> None:
     default_branch = github.detect_default_branch()
     click.echo(f"Default branch: {default_branch}")
     git = GitRepo(work_dir=work_path, default_branch=default_branch)
-    agents = [NullAgent(), CodingAgent(work_dir=work_path), PlanningAgent(work_dir=work_path)]
+    agents = [NullAgent(), CodingAgent(work_dir=work_path, repo=repo), PlanningAgent(work_dir=work_path, repo=repo)]
 
     orchestrator = Orchestrator(github=github, git=git, agents=agents)
 

--- a/loony_dev/session.py
+++ b/loony_dev/session.py
@@ -1,0 +1,26 @@
+"""Deterministic session IDs for Claude Code session continuity.
+
+Tasks that share the same (repo, key) pair will produce the same UUID v5
+session ID, allowing planning and implementation stages to share a single
+Claude Code conversation.
+"""
+from __future__ import annotations
+
+import uuid
+
+# Fixed namespace derived from a project-specific URL.  Changing this
+# invalidates all previously generated session IDs (existing sessions
+# will be abandoned, not corrupted — the next run simply starts fresh).
+_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://loonybin.dev/session")
+
+
+def session_id_for(repo: str, key: str) -> str:
+    """Return a deterministic UUID v5 string for the given repo and key.
+
+    >>> session_id_for("LoonyBin/target-repo", "issue:42")  # doctest: +SKIP
+    'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+
+    The same (repo, key) always produces the same UUID, so independently
+    computed session IDs for planning and implementation match automatically.
+    """
+    return str(uuid.uuid5(_NAMESPACE, f"{repo}:{key}"))

--- a/loony_dev/tasks/base.py
+++ b/loony_dev/tasks/base.py
@@ -52,6 +52,17 @@ class Task(ABC):
         """
         ...
 
+    @property
+    def session_key(self) -> str | None:
+        """Key for Claude Code session continuity.
+
+        Tasks that return the same key (for the same repo) will share a
+        Claude session, allowing context to carry over between stages
+        (e.g. planning -> implementation).  Return ``None`` to use a
+        fresh session each time.
+        """
+        return None
+
     @abstractmethod
     def describe(self) -> str:
         """Human/agent-readable description of work to do."""

--- a/loony_dev/tasks/ci_failure_task.py
+++ b/loony_dev/tasks/ci_failure_task.py
@@ -82,6 +82,10 @@ class CIFailureTask(Task):
     # Task interface
     # ------------------------------------------------------------------
 
+    @property
+    def session_key(self) -> str:
+        return f"pr:{self.pr.number}"
+
     def describe(self) -> str:
         check_lines = "\n".join(
             f"- {c.name} ({c.conclusion}): {c.details_url}"

--- a/loony_dev/tasks/conflict_task.py
+++ b/loony_dev/tasks/conflict_task.py
@@ -55,6 +55,10 @@ class ConflictResolutionTask(Task):
     # Task interface
     # ------------------------------------------------------------------
 
+    @property
+    def session_key(self) -> str:
+        return f"pr:{self.pr.number}"
+
     def describe(self) -> str:
         return (
             f"Resolve merge conflicts on PR #{self.pr.number}: {self.pr.title}\n\n"

--- a/loony_dev/tasks/issue_task.py
+++ b/loony_dev/tasks/issue_task.py
@@ -59,6 +59,10 @@ class IssueTask(Task):
     # Task interface
     # ------------------------------------------------------------------
 
+    @property
+    def session_key(self) -> str:
+        return f"issue:{self.issue.number}"
+
     def describe(self) -> str:
         if self.plan is not None:
             content = f"## Approved Implementation Plan\n\n{self.plan}"

--- a/loony_dev/tasks/planning_task.py
+++ b/loony_dev/tasks/planning_task.py
@@ -122,6 +122,10 @@ class PlanningTask(Task):
     # Task interface
     # ------------------------------------------------------------------
 
+    @property
+    def session_key(self) -> str:
+        return f"issue:{self.issue.number}"
+
     def describe(self) -> str:
         if self.existing_plan is None:
             return (

--- a/loony_dev/tasks/pr_review_task.py
+++ b/loony_dev/tasks/pr_review_task.py
@@ -138,6 +138,10 @@ class PRReviewTask(Task):
     # Task interface
     # ------------------------------------------------------------------
 
+    @property
+    def session_key(self) -> str:
+        return f"pr:{self.pr.number}"
+
     def describe(self) -> str:
         comments_text = "\n\n".join(
             self._format_comment(c) for c in self.pr.new_comments

--- a/loony_dev/tests/test_session.py
+++ b/loony_dev/tests/test_session.py
@@ -1,0 +1,211 @@
+"""Tests for deterministic session ID generation and CLI session logic."""
+from __future__ import annotations
+
+import uuid
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from loony_dev.session import session_id_for
+
+
+class TestSessionIdFor(unittest.TestCase):
+    """session_id_for must be deterministic and produce valid UUIDs."""
+
+    def test_deterministic(self) -> None:
+        a = session_id_for("LoonyBin/repo", "issue:42")
+        b = session_id_for("LoonyBin/repo", "issue:42")
+        self.assertEqual(a, b)
+
+    def test_valid_uuid(self) -> None:
+        result = session_id_for("LoonyBin/repo", "issue:1")
+        parsed = uuid.UUID(result)
+        self.assertEqual(parsed.version, 5)
+
+    def test_different_repos_differ(self) -> None:
+        a = session_id_for("LoonyBin/repo-a", "issue:1")
+        b = session_id_for("LoonyBin/repo-b", "issue:1")
+        self.assertNotEqual(a, b)
+
+    def test_different_keys_differ(self) -> None:
+        a = session_id_for("LoonyBin/repo", "issue:1")
+        b = session_id_for("LoonyBin/repo", "issue:2")
+        self.assertNotEqual(a, b)
+
+    def test_issue_vs_pr_differ(self) -> None:
+        a = session_id_for("LoonyBin/repo", "issue:1")
+        b = session_id_for("LoonyBin/repo", "pr:1")
+        self.assertNotEqual(a, b)
+
+    def test_planning_and_implementation_share_id(self) -> None:
+        """PlanningTask and IssueTask for the same issue must produce the same session ID."""
+        planning = session_id_for("LoonyBin/repo", "issue:42")
+        implementation = session_id_for("LoonyBin/repo", "issue:42")
+        self.assertEqual(planning, implementation)
+
+
+class TestSessionKeyOnTasks(unittest.TestCase):
+    """Task subclasses must expose the correct session_key."""
+
+    def test_planning_task_key(self) -> None:
+        from loony_dev.models import Issue
+        from loony_dev.tasks.planning_task import PlanningTask
+        task = PlanningTask(Issue(number=7, title="t", body="b"), None, [])
+        self.assertEqual(task.session_key, "issue:7")
+
+    def test_issue_task_key(self) -> None:
+        from loony_dev.models import Issue
+        from loony_dev.tasks.issue_task import IssueTask
+        task = IssueTask(Issue(number=7, title="t", body="b"))
+        self.assertEqual(task.session_key, "issue:7")
+
+    def test_pr_review_task_key(self) -> None:
+        from loony_dev.models import PullRequest
+        from loony_dev.tasks.pr_review_task import PRReviewTask
+        task = PRReviewTask(PullRequest(number=10, branch="b", title="t"))
+        self.assertEqual(task.session_key, "pr:10")
+
+    def test_ci_failure_task_key(self) -> None:
+        from loony_dev.models import PullRequest
+        from loony_dev.tasks.ci_failure_task import CIFailureTask
+        task = CIFailureTask(PullRequest(number=5, branch="b", title="t"), [])
+        self.assertEqual(task.session_key, "pr:5")
+
+    def test_conflict_task_key(self) -> None:
+        from loony_dev.models import PullRequest
+        from loony_dev.tasks.conflict_task import ConflictResolutionTask
+        task = ConflictResolutionTask(PullRequest(number=3, branch="b", title="t"))
+        self.assertEqual(task.session_key, "pr:3")
+
+    def test_stuck_item_task_has_no_session_key(self) -> None:
+        from loony_dev.models import Issue
+        from loony_dev.tasks.stuck_item_task import StuckItemCleanupTask
+        task = StuckItemCleanupTask(Issue(number=1, title="t", body="b"), 12)
+        self.assertIsNone(task.session_key)
+
+
+class TestSessionIdForOnAgent(unittest.TestCase):
+    """ClaudeQuotaMixin._session_id_for must use repo + task.session_key."""
+
+    def test_returns_id_when_repo_and_key_present(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"), repo="LoonyBin/repo")
+        task = MagicMock()
+        task.session_key = "issue:42"
+        sid = agent._session_id_for(task)
+        self.assertEqual(sid, session_id_for("LoonyBin/repo", "issue:42"))
+
+    def test_returns_none_when_no_repo(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"))  # repo defaults to ""
+        task = MagicMock()
+        task.session_key = "issue:42"
+        self.assertIsNone(agent._session_id_for(task))
+
+    def test_returns_none_when_no_session_key(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"), repo="LoonyBin/repo")
+        task = MagicMock()
+        task.session_key = None
+        self.assertIsNone(agent._session_id_for(task))
+
+
+class TestRunClaudeCli(unittest.TestCase):
+    """ClaudeQuotaMixin._run_claude_cli resume/fallback logic."""
+
+    def _make_popen_mock(self, stdout: str, stderr: str, returncode: int) -> MagicMock:
+        mock_proc = MagicMock()
+        mock_proc.__enter__ = MagicMock(return_value=mock_proc)
+        mock_proc.__exit__ = MagicMock(return_value=False)
+        mock_proc.communicate.return_value = (stdout, stderr)
+        mock_proc.returncode = returncode
+        return mock_proc
+
+    def test_no_session_id_runs_plain(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"), repo="LoonyBin/repo")
+        mock_proc = self._make_popen_mock("output", "", 0)
+
+        with patch("loony_dev.agents.claude_quota.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            stdout, stderr, rc = agent._run_claude_cli("hello", cwd=Path("/tmp"))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "output")
+        # Should NOT include --resume or --session-id
+        cmd = mock_popen.call_args[0][0]
+        self.assertNotIn("--resume", cmd)
+        self.assertNotIn("--session-id", cmd)
+
+    def test_session_id_tries_resume_first(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"), repo="LoonyBin/repo")
+        mock_proc = self._make_popen_mock("resumed output", "", 0)
+
+        with patch("loony_dev.agents.claude_quota.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            stdout, stderr, rc = agent._run_claude_cli(
+                "hello", cwd=Path("/tmp"), session_id="test-uuid",
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "resumed output")
+        # Should have used --resume
+        cmd = mock_popen.call_args[0][0]
+        self.assertIn("--resume", cmd)
+        # Should only be called once (resume succeeded)
+        self.assertEqual(mock_popen.call_count, 1)
+
+    def test_session_not_found_falls_back_to_session_id(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"), repo="LoonyBin/repo")
+
+        resume_proc = self._make_popen_mock("", "No session found for id", 1)
+        create_proc = self._make_popen_mock("fresh output", "", 0)
+
+        with patch("loony_dev.agents.claude_quota.subprocess.Popen", side_effect=[resume_proc, create_proc]) as mock_popen:
+            stdout, stderr, rc = agent._run_claude_cli(
+                "hello", cwd=Path("/tmp"), session_id="test-uuid",
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "fresh output")
+        self.assertEqual(mock_popen.call_count, 2)
+        # First call: --resume
+        first_cmd = mock_popen.call_args_list[0][0][0]
+        self.assertIn("--resume", first_cmd)
+        # Second call: --session-id
+        second_cmd = mock_popen.call_args_list[1][0][0]
+        self.assertIn("--session-id", second_cmd)
+
+    def test_real_error_does_not_fallback(self) -> None:
+        from loony_dev.agents.coding import CodingAgent
+        agent = CodingAgent(work_dir=Path("/tmp"), repo="LoonyBin/repo")
+        # Error that is NOT session-not-found
+        mock_proc = self._make_popen_mock("", "quota exceeded", 1)
+
+        with patch("loony_dev.agents.claude_quota.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            stdout, stderr, rc = agent._run_claude_cli(
+                "hello", cwd=Path("/tmp"), session_id="test-uuid",
+            )
+
+        self.assertEqual(rc, 1)
+        # Should only be called once (no fallback for real errors)
+        self.assertEqual(mock_popen.call_count, 1)
+
+
+class TestIsSessionNotFound(unittest.TestCase):
+    def test_various_patterns(self) -> None:
+        from loony_dev.agents.claude_quota import ClaudeQuotaMixin
+        self.assertTrue(ClaudeQuotaMixin._is_session_not_found("Error: No session found"))
+        self.assertTrue(ClaudeQuotaMixin._is_session_not_found("Session not found for id abc"))
+        self.assertTrue(ClaudeQuotaMixin._is_session_not_found("Could not find session"))
+        self.assertTrue(ClaudeQuotaMixin._is_session_not_found("Invalid session id"))
+        self.assertTrue(ClaudeQuotaMixin._is_session_not_found("Session does not exist"))
+
+    def test_normal_error_not_matched(self) -> None:
+        from loony_dev.agents.claude_quota import ClaudeQuotaMixin
+        self.assertFalse(ClaudeQuotaMixin._is_session_not_found("rate limit exceeded"))
+        self.assertFalse(ClaudeQuotaMixin._is_session_not_found("network error"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Introduces `loony_dev/session.py` with `session_id_for(repo, key)` — a UUID v5 utility that derives a deterministic session ID from `"{repo}:{key}"`, so independently-running planning and implementation stages for the same issue compute the same ID without any state storage
- Adds `Task.session_key` to all task subclasses: planning and issue tasks share `issue:<n>`, PR review/CI/conflict tasks share `pr:<n>`, stuck-item cleanup inherits `None`
- Extracts the duplicated `subprocess.Popen` logic from both agents into `ClaudeQuotaMixin._invoke_claude` / `_run_claude_cli`; the runner attempts `--resume <uuid>` first and falls back to `--session-id <uuid>` when no session is found
- Wires `repo` into agent constructors via `cli.py`; declared as a class-level attribute on the mixin (same pattern as `_disabled_until`) so `_session_id_for` accesses it directly
- Summary generation in `CodingAgent` deliberately bypasses the session to avoid injecting a meta-summarisation turn into conversation history that future planning/review rounds depend on

## Session flow

```
Issue #42
  PlanningTask  → session_key="issue:42" → uuid5(ns, "owner/repo:issue:42") = "abc..."
    claude -p --resume abc...        # first run: no session found
    claude -p --session-id abc...    # creates session, explores codebase, plans

  IssueTask     → session_key="issue:42" → same "abc..."
    claude -p --resume abc...        # succeeds — inherits planning context

PR #50
  PRReviewTask  → session_key="pr:50"  → uuid5(ns, "owner/repo:pr:50") = "def..."
    each review round resumes the same PR session
```

## Test plan

- [x] `test_session.py` — 21 new tests: UUID determinism, task key mapping per subclass, `_session_id_for` with/without repo, `_run_claude_cli` resume-first and fallback paths, `_is_session_not_found` pattern matching
- [x] Full suite: 168 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)