### PR TITLE
fix(github): break infinite recursion in injection warning dedup

### DIFF
--- a/loony_dev/github.py
+++ b/loony_dev/github.py
@@ -206,10 +206,21 @@ class GitHubClient:
         return result.text
 
     def _injection_warning_exists(self, item_number: int, field_name: str) -> bool:
-        """Return True if a warning comment for *field_name* has already been posted."""
-        comments = self.get_issue_comments(item_number)
+        """Return True if a warning comment for *field_name* has already been posted.
+
+        Uses a raw gh call instead of ``get_issue_comments()`` to avoid
+        infinite recursion: get_issue_comments sanitizes every comment body
+        through ``_sanitize_field``, which may call ``_post_injection_warning``
+        again, which calls this method, creating an unbounded loop.
+        """
         sentinel = f'{INJECTION_WARNING_SENTINEL}"{field_name}" -->'
-        return any(sentinel in c.body for c in comments)
+        data = self._gh_json("issue", "view", str(item_number), "--json", "comments")
+        if not isinstance(data, dict):
+            return False
+        for c in data.get("comments", []):
+            if sentinel in c.get("body", ""):
+                return True
+        return False
 
     def _post_injection_warning(
         self,

--- a/loony_dev/tests/test_injection_dedup.py
+++ b/loony_dev/tests/test_injection_dedup.py
@@ -4,6 +4,10 @@ The bot polls GitHub on every cycle. Without deduplication, a prompt injection
 detected on the read path would post a new warning comment on every poll —
 spamming the issue indefinitely. The fix checks whether a warning for the same
 field already exists in the comments before posting.
+
+``_injection_warning_exists`` uses a raw ``_gh_json`` call instead of
+``get_issue_comments`` to avoid infinite recursion (get_issue_comments
+sanitizes bodies → _sanitize_field → _post_injection_warning → loop).
 """
 from __future__ import annotations
 
@@ -24,8 +28,14 @@ def _sentinel(field: str) -> str:
     return f'{INJECTION_WARNING_SENTINEL}"{field}" -->'
 
 
-def _warning_comment(field: str) -> Comment:
-    return Comment(author=BOT_NAME, body=f"{_sentinel(field)}\n> [!WARNING]\n> ...", created_at="2024-01-01T00:00:00Z")
+def _raw_comments_response(*comments: dict) -> dict:
+    """Build the dict that ``_gh_json("issue", "view", ...)`` returns."""
+    return {"comments": list(comments)}
+
+
+def _raw_warning_comment(field: str) -> dict:
+    """A raw comment dict (as returned by gh) containing the sentinel."""
+    return {"author": {"login": BOT_NAME}, "body": f"{_sentinel(field)}\n> [!WARNING]\n> ..."}
 
 
 class TestInjectionWarningDedup(unittest.TestCase):
@@ -35,7 +45,7 @@ class TestInjectionWarningDedup(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_no_prior_warning_posts_comment(self) -> None:
         client = _make_client()
-        client.get_issue_comments = MagicMock(return_value=[])
+        client._gh_json = MagicMock(return_value=_raw_comments_response())
         client.post_comment = MagicMock()
 
         client._post_injection_warning(1, "body", [])
@@ -47,7 +57,7 @@ class TestInjectionWarningDedup(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_prior_warning_suppresses_comment(self) -> None:
         client = _make_client()
-        client.get_issue_comments = MagicMock(return_value=[_warning_comment("body")])
+        client._gh_json = MagicMock(return_value=_raw_comments_response(_raw_warning_comment("body")))
         client.post_comment = MagicMock()
 
         client._post_injection_warning(1, "body", [])
@@ -60,7 +70,7 @@ class TestInjectionWarningDedup(unittest.TestCase):
     def test_different_field_posts_comment(self) -> None:
         client = _make_client()
         # Warning exists for "title", but we're checking "body"
-        client.get_issue_comments = MagicMock(return_value=[_warning_comment("title")])
+        client._gh_json = MagicMock(return_value=_raw_comments_response(_raw_warning_comment("title")))
         client.post_comment = MagicMock()
 
         client._post_injection_warning(1, "body", [])
@@ -73,13 +83,13 @@ class TestInjectionWarningDedup(unittest.TestCase):
     def test_different_item_posts_comment(self) -> None:
         client = _make_client()
 
-        def _comments(number: int) -> list[Comment]:
+        def _gh_json_side_effect(*args: str) -> dict:
             # Issue #1 has a warning; issue #2 does not
-            if number == 1:
-                return [_warning_comment("body")]
-            return []
+            if "1" in args:
+                return _raw_comments_response(_raw_warning_comment("body"))
+            return _raw_comments_response()
 
-        client.get_issue_comments = MagicMock(side_effect=_comments)
+        client._gh_json = MagicMock(side_effect=_gh_json_side_effect)
         client.post_comment = MagicMock()
 
         client._post_injection_warning(2, "body", [])
@@ -92,9 +102,8 @@ class TestInjectionWarningDedup(unittest.TestCase):
     def test_restart_survival_no_repost(self) -> None:
         """A freshly-constructed client with no in-memory state must not
         re-post if the warning comment is already present in GitHub."""
-        # Simulate a fresh instance — no shared state with any prior instance
         fresh_client = GitHubClient(repo="owner/repo", bot_name=BOT_NAME)
-        fresh_client.get_issue_comments = MagicMock(return_value=[_warning_comment("body")])
+        fresh_client._gh_json = MagicMock(return_value=_raw_comments_response(_raw_warning_comment("body")))
         fresh_client.post_comment = MagicMock()
 
         fresh_client._post_injection_warning(1, "body", [])
@@ -106,7 +115,7 @@ class TestInjectionWarningDedup(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_posted_comment_body_contains_sentinel(self) -> None:
         client = _make_client()
-        client.get_issue_comments = MagicMock(return_value=[])
+        client._gh_json = MagicMock(return_value=_raw_comments_response())
         posted_bodies: list[str] = []
         client.post_comment = MagicMock(side_effect=lambda n, b: posted_bodies.append(b))
 
@@ -114,6 +123,22 @@ class TestInjectionWarningDedup(unittest.TestCase):
 
         self.assertEqual(len(posted_bodies), 1)
         self.assertIn(_sentinel("body"), posted_bodies[0])
+
+    # ------------------------------------------------------------------
+    # 7. Regression: _injection_warning_exists must NOT call
+    #    get_issue_comments (which sanitizes → infinite recursion)
+    # ------------------------------------------------------------------
+    def test_injection_warning_exists_does_not_use_get_issue_comments(self) -> None:
+        """Ensure the recursion bug cannot regress."""
+        client = _make_client()
+        client._gh_json = MagicMock(return_value=_raw_comments_response())
+        client.get_issue_comments = MagicMock(
+            side_effect=AssertionError("must not call get_issue_comments from _injection_warning_exists"),
+        )
+
+        # Should complete without hitting get_issue_comments
+        result = client._injection_warning_exists(1, "body")
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `_injection_warning_exists()` called `get_issue_comments()`, which sanitizes every comment through `_sanitize_field()` — creating an infinite recursion loop when any comment triggered injection detection (`_sanitize_field` → `_post_injection_warning` → `_injection_warning_exists` → `get_issue_comments` → `_sanitize_field` → …)
- Replaced with a raw `_gh_json()` call that checks for the sentinel string directly without sanitization
- Added regression test that will fail if `get_issue_comments` is ever called from `_injection_warning_exists` again

## Test plan
- [x] All 19 existing tests pass (`test_injection_dedup.py` + `test_github_own_comments.py`)
- [x] New regression test `test_injection_warning_exists_does_not_use_get_issue_comments` guards against reintroduction
- [ ] Deploy and verify issue #87 no longer triggers repeated injection warnings in `loony-worker.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)